### PR TITLE
search fix for #9

### DIFF
--- a/client/tabular.js
+++ b/client/tabular.js
@@ -191,15 +191,10 @@ Template.tabular.rendered = function () {
 };
 
 function cleanFieldName(field) {
-  // for field names with a dot, we just need
-  // the top level field name
-  var dot = field.indexOf(".");
-  if (dot !== -1) {
-    field = field.slice(0, dot);
-  }
 
-  // If it's referencing an array, strip off the brackets
-  field = field.split('[')[0];
+  // If it's referencing an array, replace the brackets
+  // This will only work with an object which doesn't have ["foo"]
+  field = field.replace(/\[\w+\]/, "");
 
   return field;
 }


### PR DESCRIPTION
maybe not the most elegant, but because cleanFieldName is only used in one spot for searching, I thought this would be sufficient

fix cleaning of name to not remove dots (allows for searching into an ob...ject) and also removes brackets, making it a dot notation which will allow mongo to properly query the array of the object.

for example: 

1. "profile.name" does not become "profile" but stays "profile.name". 
2. "emails[0].address" becomes "email.address" which makes the db query something like db.users.findOne({'emails.address': {$regex:"gmail.com"}})