### PR TITLE
Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ Some useful tips
 
 ```js
 Template.myTemplate.events({
-  'click tr': function (event) {
+  'click tbody tr': function (event) {
     var dataTable = $(event.target).closest('table').DataTable();
     var rowData = dataTable.row(event.currentTarget).data();
   }


### PR DESCRIPTION
Previous example would be triggered by clicks on the table header as well, leading to `undefined` for `rowdata`