### PR TITLE
Enabling field changes to be made reactively

### DIFF
--- a/client/tableInit.js
+++ b/client/tableInit.js
@@ -84,6 +84,6 @@ tableInit = function tableInit(tabularTable, template) {
   });
 
   template.tabular.columns = columns;
-  template.tabular.fields = fields;
+  template.tabular.fields.set(fields);
   template.tabular.searchFields = searchFields;
 };

--- a/client/tabular.js
+++ b/client/tabular.js
@@ -186,6 +186,7 @@ Template.tabular.rendered = function () {
       var dt = $tableElement.DataTable();
       if (dt) {
         dt.destroy();
+        $tableElement.empty();     // DataTables needs this in case # of clumns changes
       }
     }
 


### PR DESCRIPTION
With respect to issue #85.

I made the following changes to allow changes to fields to refresh the table reactively...

1) changed tabular.fields to be reactive - this is used to ensure a new subscription is generated when it changes

2) I now regenerate ajaxOptions each time a new DataTable is created (because otherwise it gets contaminated with old aoColumns by the prior DataTable)

3) Commented out the block at new line 63 that was preventing options from being updated if the table name hasn't changed... this piece makes me nervous about side effects - that reload is probably required in some circumstances... it may need to be replaced, but further down in that autorun.  

EDIT: I missed there's already a reload further down, so #3 probably isn't actually an issue.

Thoughts?

