### PR TITLE
adds changeSelector method

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,22 @@ TabularTables.People = new Tabular.Table({
 });
 ```
 
+
+## Modifying the selector
+
+If your table requires the selector to be modified before it's published, you can modify it with the `modifySelector` method. This can be useful for modifying what will be returned in a search.
+
+```js
+TabularTables.Posts = new Tabular.Table({
+  // other properties...
+  modifySelector: function(selector) {
+    // modify it here ...
+    return selector;
+  }
+});
+```
+
+
 ## Security
 
 You can optionally provide an `allow` and/or `allowFields` function to control which clients can get the published data. These are used by the built-in publications on the server only.

--- a/common.js
+++ b/common.js
@@ -30,6 +30,7 @@ Tabular.Table = function (options) {
   self.onUnload = options.onUnload;
   self.allow = options.allow;
   self.allowFields = options.allowFields;
+  self.changeSelector = options.changeSelector;
 
   if (_.isArray(options.extraFields)) {
     var fields = {};

--- a/server/tabular.js
+++ b/server/tabular.js
@@ -83,6 +83,11 @@ Meteor.publish("tabular_getInfo", function(tableName, selector, sort, skip, limi
 
   selector = selector || {};
 
+  // Allow the user to modify the selector before we use it
+  if (typeof table.changeSelector === 'function') {
+    selector = table.changeSelector(selector);
+  }
+
   // Apply the server side selector specified in the tabular
   // table constructor. Both must be met, so we join
   // them using $and, allowing both selectors to have


### PR DESCRIPTION
Allows the user to modify the selector before it’s used in the
publication.

This can be helpful for narrowing results to a certain column based on
the search string used or for encrypting the search string before it’s
used in the query.

I’m not sure how useful this is for others but I thought I would submit
the PR just in case you wanted to add it.