### PR TITLE
fix search selector when $or is used in selector

### DIFF
--- a/client/pubSelector.js
+++ b/client/pubSelector.js
@@ -28,5 +28,5 @@ getPubSelector = function getPubSelector(selector, searchString, searchFields, s
       }
     });
 
-    return _.extend({}, selector, {$or: searches});
+    return {$and: [selector, {$or: searches}]};
   };


### PR DESCRIPTION
Hello,

I found a small bug with the search feature.  If the user's selector's top-level construct is a {$or: ...} then this is overwritten with _.extend() rather than being AND'd with the search critera:

> _.extend({}, {$or: 'user-selector stuff'}, {$or: 'searches'})
{ '$or': 'searches' }

This merge request will construct an explicit {$and } selector with the user's selector and the search selector.