### PR TITLE
add support for columns().search()

### DIFF
--- a/client/pubSelector.js
+++ b/client/pubSelector.js
@@ -1,32 +1,59 @@
 /* global getPubSelector:true, _ */
 
-getPubSelector = function getPubSelector(selector, searchString, searchFields, searchCaseInsensitive) {
-    if (!searchString || !searchFields || searchFields.length === 0) {
-      return selector;
+getPubSelector = function getPubSelector(selector, searchString, searchFields, searchCaseInsensitive, columns) {
+
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  // if search was invoked via .columns().search(), build a query off that
+  // https://datatables.net/reference/api/columns().search()
+  // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  var searchColumns = _.filter(columns, function(column) {
+    return column.search && column.search.value !== '';
+  });
+
+  // required args
+  if ((!searchString && searchColumns.length === 0) || !searchFields || searchFields.length === 0) {
+    return selector;
+  }
+
+  // See if we can resolve the search string to a number,
+  // in which case we use an extra query because $regex
+  // matches string fields only.
+  var searches = [];
+
+  // normalize search fields array to mirror the structure 
+  // as passed by the datatables ajax.data function
+  searchFields = _.map(searchFields, function(field) {
+    return { 
+      data: field, 
+      search: { 
+        value: searchString 
+      } 
+    }; 
+  });
+
+  var searchTerms = _.isEmpty(searchColumns) ? searchFields : searchColumns;
+
+  _.each(searchTerms, function(field) {
+    var m1 = {}, m2 = {};
+
+    var numSearchString = Number(field.search.value);
+
+    // String search
+    m1[field.data] = { $regex: field.search.value };
+
+    // DataTables searches are case insensitive by default
+    if (searchCaseInsensitive !== false) {
+      m1[field.data].$options = "i";
     }
 
-    // See if we can resolve the search string to a number,
-    // in which case we use an extra query because $regex
-    // matches string fields only.
-    var numSearchString = Number(searchString), searches = [];
+    searches.push(m1);
 
-    _.each(searchFields, function(field) {
-      var m1 = {}, m2 = {};
+    // Number search
+    if (!isNaN(numSearchString)) {
+      m2[field.data] = numSearchString;
+      searches.push(m2);
+    }
+  });
 
-      // String search
-      m1[field] = {$regex: searchString};
-      // DataTables searches are case insensitive by default
-      if (searchCaseInsensitive !== false) {
-        m1[field].$options = "i";
-      }
-      searches.push(m1);
-
-      // Number search
-      if (!isNaN(numSearchString)) {
-        m2[field] = numSearchString;//{$where: '/' + numSearchString + '/.test(this.' + field + ')'};
-        searches.push(m2);
-      }
-    });
-
-    return _.extend({}, selector, {$or: searches});
-  };
+  return _.extend({}, selector, { $or: searches });
+};

--- a/client/tabular.js
+++ b/client/tabular.js
@@ -57,7 +57,8 @@ Template.tabular.rendered = function () {
         template.tabular.selector,
         (data.search && data.search.value) || null,
         template.tabular.searchFields,
-        template.tabular.searchCaseInsensitive
+        template.tabular.searchCaseInsensitive,
+        data.columns || null
       );
       template.tabular.pubSelector.set(pubSelector);
 


### PR DESCRIPTION
When you use the `data.ajax` option in **DataTables**, the object that is passed to the function you provide, of course, looks something like:

``` javascript
{
  columns: [{ data: 'col1' }, ...],
  search: {
    value: 'search terms'
  },
  ...
}
```

When you invoke `table.columns().search('some search terms')`, those search terms do not populate the global search object, rather they get attached to the objects in the columns array like so:

``` javascript
{
  columns: [{ data: 'col1', search: { value: 'some search terms', ... } }, ... ],
  search: {
    value: '',
  },
  ...
}
```

Anyway, I just added the `columns` array as a 5th argument to `.getPubSelector()` and then slightly refactored `.getPubSelector()` to check the columns for non-empty search terms and build the query/selector out of those instead, or otherwise to use the global search object as usual.
