### PR TITLE
Add refresh throttling & fix record ID reactivity

### DIFF
--- a/client/tabular.js
+++ b/client/tabular.js
@@ -24,6 +24,7 @@ var tabularOnRendered = function () {
   template.tabular.searchFields = null;
   template.tabular.searchCaseInsensitive = true;
   template.tabular.tableName = new ReactiveVar(null);
+  template.tabular.throttleRefresh = new ReactiveVar(null);
   template.tabular.options = new ReactiveVar({}, Util.objectsAreEqual);
   template.tabular.docPub = new ReactiveVar(null);
   template.tabular.collection = new ReactiveVar(null);
@@ -151,6 +152,7 @@ var tabularOnRendered = function () {
     template.tabular.searchCaseInsensitive = (tabularTable.options && tabularTable.options.search && tabularTable.options.search.caseInsensitive) || true;
     template.tabular.options.set(tabularTable.options);
     template.tabular.tableName.set(tabularTable.name);
+    template.tabular.throttleRefresh.set(tabularTable.throttleRefresh);
     template.tabular.docPub.set(tabularTable.pub);
     template.tabular.collection.set(tabularTable.collection);
 
@@ -182,7 +184,8 @@ var tabularOnRendered = function () {
       template.tabular.pubSelector.get(),
       template.tabular.sort.get(),
       template.tabular.skip.get(),
-      template.tabular.limit.get()
+      template.tabular.limit.get(),
+      template.tabular.throttleRefresh.get()
     );
   });
 

--- a/common.js
+++ b/common.js
@@ -31,6 +31,7 @@ Tabular.Table = function (options) {
   self.allow = options.allow;
   self.allowFields = options.allowFields;
   self.changeSelector = options.changeSelector;
+  self.throttleRefresh = options.throttleRefresh;
 
   if (_.isArray(options.extraFields)) {
     var fields = {};


### PR DESCRIPTION
First off, thanks for an amazing library, Eric! Our organization has been using Tabular for an internal application and loving it, but we've recently added a batch reprocessing step on our backend that changes rows in our Mongo database multiple times a second, and our tables sorted by last-reprocessing-date went crazy. Not only was Tabular trying to publish DDP records every time the record count incremented - so fast, in fact, that you couldn't interact with the interface because the DOM was updating faster than click events on existing rows could be processed! - but because of the optimization [`filteredRecordIds.push(id);`](https://github.com/aldeed/meteor-tabular/blob/2867ed41b04833a77c8016896d14fc7c028e602f/server/tabular.js#L153), which didn't take into account the limit, we would see hundreds of rows appear on screen when we had set the limit to 10 - clearly unexpected behavior!

This PR fixes the bug (by re-querying the filtered collection each time before publishing) and adds the ability to throttle the rate at which Tabular republishes `getInfo`, which can be added in milliseconds as a throttleRefresh option. If throttleRefresh is omitted, the records are published every time the countCursor sees changes, just as before, but with the added correctness from the bugfix, so it is completely opt-in, and any bugs in the throttling logic shouldn't affect anything else.

Since any organization running bulk worker tasks that change Mongo records could see this problem, we'd love to see this pull request accepted. I'm happy to do any cleanup & documentation to get this ready-to-go.

Thanks again!