### PR TITLE
Support remote collections

### DIFF
--- a/client/tableRecords.js
+++ b/client/tableRecords.js
@@ -2,7 +2,24 @@
 
 // We are creating a named client Collection that we will only modify from server
 Tabular.tableRecords = new Mongo.Collection('tabular_records');
+Tabular.remoteTableRecords = [];
 
-Tabular.getRecord = function(name) {
+Tabular.getRecord = function(name, collection) {
+  if (collection && collection._connection)
+    return Tabular.getRemoteRecord(name, collection._connection);
   return Tabular.tableRecords.findOne(name);
+};
+
+Tabular.getRemoteRecord = function(name, connection) {
+  var remote = _.find(Tabular.remoteTableRecords, function (remote) {
+    return remote.connection === connection;
+  });
+  if (!remote) {
+    var len = Tabular.remoteTableRecords.push({
+      connection: connection,
+      tableRecords: new Mongo.Collection('tabular_records', {connection: connection})
+    });
+    remote = Tabular.remoteTableRecords[len - 1];
+  }
+  return remote.tableRecords.findOne(name);
 };

--- a/client/tabular.js
+++ b/client/tabular.js
@@ -28,6 +28,7 @@ var tabularOnRendered = function () {
   template.tabular.options = new ReactiveVar({}, Util.objectsAreEqual);
   template.tabular.docPub = new ReactiveVar(null);
   template.tabular.collection = new ReactiveVar(null);
+  template.tabular.connection = null;
   template.tabular.ready = new ReactiveVar(false);
   template.tabular.recordsTotal = 0;
   template.tabular.recordsFiltered = 0;
@@ -166,6 +167,9 @@ var tabularOnRendered = function () {
     template.tabular.tableName.set(tabularTable.name);
     template.tabular.docPub.set(tabularTable.pub);
     template.tabular.collection.set(tabularTable.collection);
+    if (tabularTable.collection && tabularTable.collection._connection) {
+      template.tabular.connection = tabularTable.collection._connection;
+    }
 
     // userOptions rerun should do this?
     if (table) {
@@ -189,7 +193,9 @@ var tabularOnRendered = function () {
 
     //console.log('tabular_getInfo autorun');
 
-    Meteor.subscribe(
+    var connection = template.tabular.connection;
+    var context = connection || Meteor;
+    context.subscribe(
       "tabular_getInfo",
       template.tabular.tableName.get(),
       template.tabular.pubSelector.get(),
@@ -209,7 +215,8 @@ var tabularOnRendered = function () {
     // It does not cause reruns based on the documents themselves
     // changing.
     var tableName = template.tabular.tableName.get();
-    var tableInfo = Tabular.getRecord(tableName) || {};
+    var collection = template.tabular.collection.get();
+    var tableInfo = Tabular.getRecord(tableName, collection) || {};
 
     //console.log('tableName and tableInfo autorun', tableName, tableInfo);
 
@@ -295,7 +302,7 @@ var tabularOnRendered = function () {
     // * `selector` attribute changed reactively
     // * Docs were added/changed/removed by this user or
     //   another user, causing visible result set to change.
-    var tableInfo = Tabular.getRecord(tableName);
+    var tableInfo = Tabular.getRecord(tableName, collection);
 
     if (!collection || !tableInfo) {
       return;

--- a/common.js
+++ b/common.js
@@ -27,9 +27,9 @@ Tabular.Table = function (options) {
 
   self.pub = options.pub || 'tabular_genericPub';
 
-  // By default we use core `Meteor.subscribe`, but you can pass
+  // By default we use core `Meteor.subscribe` or `collection._connection`, but you can pass
   // a subscription manager like `sub: new SubsManager({cacheLimit: 20, expireIn: 3})`
-  self.sub = options.sub || Meteor;
+  self.sub = options.sub || options.collection._connection || Meteor;
 
   self.onUnload = options.onUnload;
   self.allow = options.allow;


### PR DESCRIPTION
Example:

```javascript
const connection = DDP.connect('http://localhost:3000');
const Jobs = new Mongo.Collection('jobs', { connection });
const table = new TabularTable({
  collection: Jobs,
  //...
});
```

With this setup both apps need to define the same tabular table so they can communicate. It should be possible to lift this constraint (maybe by providing an option to override `tabular_getInfo`) but it's not part of this PR.