### PR TITLE
fixed id check for objects

### DIFF
--- a/server/tabular.js
+++ b/server/tabular.js
@@ -160,7 +160,7 @@ Meteor.publish("tabular_getInfo", function(tableName, selector, sort, skip, limi
     },
     removed: function (id) {
       //console.log("REMOVED");
-      filteredRecordIds = _.without(filteredRecordIds, id);
+      filteredRecordIds = _.without(filteredRecordIds, _.findWhere(filteredRecordIds, id));
       updateRecords();
     }
   });


### PR DESCRIPTION
Please merge it.
I think I've fixed this issue https://github.com/aldeed/meteor-tabular/issues/277#issuecomment-195150587

The problem was with underscore's without method and MongoObjects as ids.