### PR TITLE
Ensure counting runs in a Fiber, even if throttled (#278)

### DIFF
--- a/server/tabular.js
+++ b/server/tabular.js
@@ -140,6 +140,8 @@ Meteor.publish("tabular_getInfo", function(tableName, selector, sort, skip, limi
     }
   };
 
+  updateRecords = Meteor.bindEnvironment(updateRecords);
+
   if (table.throttleRefresh) {
     updateRecords = _.throttle(updateRecords, table.throttleRefresh);
   }


### PR DESCRIPTION
From https://github.com/aldeed/meteor-tabular/issues/278#issuecomment-217318112 :

The core of the problem is that .count() is called synchronously, and regardless of when/where countCursor was created, this call needs to be in a Fiber if Meteor had any reason to believe that Mongo changed separately from its own actions (i.e. another server or external process wrote to the database).

Meteor.setTimeout, which I introduced in my earlier fix, created a Fiber and fixed some of the problems... but it was doing so around the _.throttle. And _.throttle(func) can sometimes call func synchronously, but sometimes asynchronously if it actually hits the throttle condition. So in situations where the count was dirty, and throttling was triggered, then the Fiber would never wrap the actual thing that we needed a Fiber to wrap!

So the actual fix should be a lot simpler than my branch: just wrap updateRecords in Meteor.bindEnvironment before it gets throttle-wrapped. I'm doing some final testing and will make a PR shortly.
