### PR TITLE
Fixed an issue where processing indicator wouldn't go away

### DIFF
--- a/client/tabular.js
+++ b/client/tabular.js
@@ -48,9 +48,6 @@ var tabularOnRendered = function () {
       // the first subscription, which will then trigger the
       // second subscription.
 
-      template.tabular.isLoading.set(true);
-      //console.log('data', template.tabular.data);
-
       // Update skip
       template.tabular.skip.set(data.start);
       Session.set('Tabular.LastSkip', data.start);
@@ -188,6 +185,18 @@ var tabularOnRendered = function () {
     }
   });
 
+  template.autorun(function () {
+    // these 5 are the parameters passed to "tabular_getInfo" subscription
+    // so when they *change*, set the isLoading flag to true
+    template.tabular.tableName.get();
+    template.tabular.pubSelector.get();
+    template.tabular.sort.get();
+    template.tabular.skip.get();
+    template.tabular.limit.get();
+
+    template.tabular.isLoading.set(true);
+  });
+
   // First Subscription
   // Subscribe to an array of _ids that should be on the
   // current page of the table, plus some aggregate
@@ -211,7 +220,7 @@ var tabularOnRendered = function () {
       template.tabular.limit.get(),
         function() {
           // this callback is there only to handle a case where a change in pubSelector
-          // doesn't actually get any new rows. This causes the 'processing' indicator 
+          // doesn't actually get any new rows. This causes the 'processing' indicator
           // to be displayed but never hidden
 
           // most of this code is copy & pasted from other autorun blocks

--- a/client/tabular.js
+++ b/client/tabular.js
@@ -208,7 +208,28 @@ var tabularOnRendered = function () {
       template.tabular.pubSelector.get(),
       template.tabular.sort.get(),
       template.tabular.skip.get(),
-      template.tabular.limit.get()
+      template.tabular.limit.get(),
+        function() {
+          // this callback is there only to handle a case where a change in pubSelector
+          // doesn't actually get any new rows. This causes the 'processing' indicator 
+          // to be displayed but never hidden
+
+          // most of this code is copy & pasted from other autorun blocks
+          var tableName = Tracker.nonreactive(function () {
+            return template.tabular.tableName.get();
+          });
+
+          var tableInfo = Tabular.getRecord(tableName) || {};
+
+          var collection = template.tabular.collection.get();
+
+          // we only care about the count, so no fields selector
+          // if cursor already has all the records, hide the processing indicator
+          var cursorCount = collection.find({_id: {$in: tableInfo.ids}}).count();
+          if (cursorCount === tableInfo.ids.length) {
+            template.tabular.isLoading.set(false);
+          }
+        }
     );
   });
 


### PR DESCRIPTION
Fixed an issue where the processing indicator wouldn't go away. This happened when the pubSelector was changed, but the change didn't result in any new rows.

For example, if you have a collection with 30 rows, going from page size 50 to page size 100 doesn't actually get any new rows. So some of the autorun blocks were never triggered.

This possibly addresses https://github.com/aldeed/meteor-tabular/issues/252
