### PR TITLE
Add an option to not perform expensive count()s

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -2,9 +2,13 @@
   "dependencies": {
     "datatables": {
       "version": "1.10.9",
+      "resolved": "https://registry.npmjs.org/datatables/-/datatables-1.10.9.tgz",
+      "from": "datatables@1.10.9",
       "dependencies": {
         "jquery": {
-          "version": "2.1.4"
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz",
+          "from": "jquery@2.1.4"
         }
       }
     }

--- a/.versions
+++ b/.versions
@@ -1,4 +1,3 @@
-aldeed:tabular@1.6.1
 allow-deny@1.0.3
 babel-compiler@6.6.1
 babel-runtime@0.1.7
@@ -26,6 +25,7 @@ htmljs@1.0.8
 id-map@1.0.6
 jquery@1.11.7
 logging@1.0.11
+maxko87:tabular-nocounts@1.6.1_1
 meteor@1.1.13
 minifier-js@1.1.10
 minimongo@1.0.13

--- a/client/tabular.html
+++ b/client/tabular.html
@@ -1,6 +1,10 @@
 <template name="tabular">
   <div>
     {{! somehow the div wrapper helps the table get cleaned up properly for example when switching between routes}}
-    <table {{atts}}></table>
+    {{#if Template.subscriptionsReady}}
+      <table {{atts}}></table>
+    {{else}}
+      {{> loading_page}}
+    {{/if}}
   </div>
 </template>

--- a/client/tabular.js
+++ b/client/tabular.js
@@ -113,7 +113,7 @@ var tabularOnRendered = function () {
               table.search(this.value).draw();
             }
             else {
-              replaceSearchLabel("Search (click enter):");
+              replaceSearchLabel("Search (hit enter):");
             }
           });
       }

--- a/client/tabular.js
+++ b/client/tabular.js
@@ -99,12 +99,21 @@ var tabularOnRendered = function () {
     initComplete: function () {
       var options = template.tabular.options.get();
       if (options.search && options.search.onEnterOnly) {
+        var replaceSearchLabel = function(newText){
+          $('.dataTables_filter label').contents().filter(function() {
+            return this.nodeType === 3 && this.textContent.trim().length;
+          }).replaceWith(newText);
+        }
         $('.dataTables_filter input')
           .unbind()
           .bind('keyup change', function (event) {
             if (!table) return;
             if (event.keyCode === 13 || this.value === '') {
+              replaceSearchLabel("Search:");
               table.search(this.value).draw();
+            }
+            else {
+              replaceSearchLabel("Search (click enter):");
             }
           });
       }

--- a/common.js
+++ b/common.js
@@ -36,6 +36,7 @@ Tabular.Table = function (options) {
   self.allowFields = options.allowFields;
   self.changeSelector = options.changeSelector;
   self.throttleRefresh = options.throttleRefresh;
+  self.alternativeCount = options.alternativeCount;
 
   if (_.isArray(options.extraFields)) {
     var fields = {};

--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@
 Package.describe({
   name: 'maxko87:tabular-nocounts',
   summary: 'Datatables for large or small datasets in Meteor',
-  version: '1.6.1_1',
+  version: '1.6.1_2',
   git: 'https://github.com/maxko87/meteor-tabular.git'
 });
 

--- a/package.js
+++ b/package.js
@@ -1,10 +1,10 @@
 /* global Package, Npm */
 
 Package.describe({
-  name: 'aldeed:tabular',
+  name: 'maxko87:tabular-nocounts',
   summary: 'Datatables for large or small datasets in Meteor',
-  version: '1.6.1',
-  git: 'https://github.com/aldeed/meteor-tabular.git'
+  version: '1.6.1_1',
+  git: 'https://github.com/maxko87/meteor-tabular.git'
 });
 
 Npm.depends({

--- a/server/tabular.js
+++ b/server/tabular.js
@@ -115,7 +115,12 @@ Meteor.publish("tabular_getInfo", function(tableName, selector, sort, skip, limi
 
   var recordReady = false;
   var updateRecords = function updateRecords() {
-    var currentCount = countCursor.count();
+    if(table.alternativeCount){
+      var currentCount = table.alternativeCount(self.userId);
+    }
+    else {
+      var currentCount = countCursor.count();
+    }
 
     // From https://datatables.net/manual/server-side
     // recordsTotal: Total records, before filtering (i.e. the total number of records in the database)


### PR DESCRIPTION
[Counting in MongoDB is slow, even on indexed fields.] (https://www.compose.com/articles/counting-and-not-counting-with-mongodb/) The only reason counts are used in this package is to display the X in "Showing 1-50 of X items" at the bottom of the table and figuring out when to stop allowing the user to click "Next Page".

This PR is an effective way to do this, especially if you can cache the count on the user, as shown here:

  ```
TabularTables.FbaItems = new Tabular.Table
    ...
    alternativeCount: (userId) ->
      Meteor.users.findOne({_id: userId}).cachedCounts?.item_count or 0
```