### PR TITLE
Change search text for onEnterOnly

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -135,12 +135,21 @@ Template.tabular.onRendered(function () {
     initComplete: function () {
       var options = template.tabular.options.get();
       if (options.search && options.search.onEnterOnly) {
+        var replaceSearchLabel = function(newText){
+          $('.dataTables_filter label').contents().filter(function() {
+            return this.nodeType === 3 && this.textContent.trim().length;
+          }).replaceWith(newText);
+        }
         $('.dataTables_filter input')
           .unbind()
           .bind('keyup change', function (event) {
             if (!table) return;
             if (event.keyCode === 13 || this.value === '') {
+              replaceSearchLabel("Search:");
               table.search(this.value).draw();
+            }
+            else {
+              replaceSearchLabel("Search (hit enter):");
             }
           });
       }


### PR DESCRIPTION
We change "Search:" to "Search (hit enter):" when onEnterOnly is enabled, to indicate to the user that they need to hit enter.