### PR TITLE
Fixed error `Meteor.users` is not `instanceof` Mongo.Collection

### DIFF
--- a/common/Tabular.js
+++ b/common/Tabular.js
@@ -10,7 +10,9 @@ Tabular.Table = class {
     if (!options) throw new Error('Tabular.Table options argument is required');
     if (!options.name) throw new Error('Tabular.Table options must specify name');
     if (!options.columns) throw new Error('Tabular.Table options must specify columns');
-    if (!(options.collection instanceof Mongo.Collection)) {
+    if (!(options.collection instanceof Mongo.Collection
+      || options.collection instanceof Mongo.constructor // Fix: error if `collection: Meteor.users`
+    )) {
       throw new Error('Tabular.Table options must specify collection');
     }
 


### PR DESCRIPTION
Hello @aldeed.

This fix make the package `aldeed:tabular` comparable with the `Meteor.users` collection.

## How to reproduce bug

1. Install meteor.
2. Add `aldeed:tabular`.
3. Try make tabular table with users:

```js
import Tabular from 'meteor/aldeed:tabular';

Meteor.startup(()=> {

  new Tabular.Table({
    name: 'Users', // because Meteor.users internal collection has name 'users'
    collection: Meteor.users,
    ...
  });

});
```

## How to fix

Add check `options.collection instanceof Mongo.constructor`.