### PR TITLE
faster page switching when cell templates are used

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -124,7 +124,7 @@ Template.tabular.onRendered(function () {
       // Matters on the first run only.
       template.tabular.ready.set(true);
 
-      //if we are redrawing the same items in the same order, don't redraw 
+      //if we are redrawing the same items in the same order, don't redraw
       var redraw = true;
       if(template.tabular.lastData && template.tabular.data.length == template.tabular.lastData.length){
         redraw = !template.tabular.data.some(function(item, index){

--- a/client/main.js
+++ b/client/main.js
@@ -441,7 +441,7 @@ Template.tabular.onRendered(function () {
             //the data for this template may have changed, so re-render
             //TODO: might be better to check if the values used have changed somehow?
             if(item.template.dataVar){
-              item.template.dataVar.set(item.template.dataVar.get());
+              item.template.dataVar.set(_.extend(item.template.dataVar.get(), newDoc));
             }
           });
         }

--- a/client/main.js
+++ b/client/main.js
@@ -124,14 +124,23 @@ Template.tabular.onRendered(function () {
       // Matters on the first run only.
       template.tabular.ready.set(true);
 
+      var redraw = true;
+      if(template.tabular.lastData && template.tabular.data.length == template.tabular.lastData.length){
+        redraw = !template.tabular.data.some(function(item, index){
+          return item._id == template.tabular.lastData[index]._id;
+        });
+        redraw = true;
+      }
       //console.log('ajax');
-
-      callback({
-        draw: data.draw,
-        recordsTotal: template.tabular.recordsTotal,
-        recordsFiltered: template.tabular.recordsFiltered,
-        data: template.tabular.data
-      });
+      if(redraw){
+        callback({
+          draw: data.draw,
+          recordsTotal: template.tabular.recordsTotal,
+          recordsFiltered: template.tabular.recordsFiltered,
+          data: template.tabular.data
+        });
+        template.tabular.lastData = template.tabular.data;
+      }
 
     },
     initComplete: function () {
@@ -424,7 +433,6 @@ Template.tabular.onRendered(function () {
 
     // Get the updated list of docs we should be showing
     var cursor = collection.find({_id: {$in: tableInfo.ids}}, findOptions);
-
     //console.log('tableInfo, fields, sort, find autorun', cursor.count());
 
     // We're subscribing to the docs just in time, so there's

--- a/client/main.js
+++ b/client/main.js
@@ -124,6 +124,7 @@ Template.tabular.onRendered(function () {
       // Matters on the first run only.
       template.tabular.ready.set(true);
 
+      //if we are redrawing the same items in the same order, don't redraw 
       var redraw = true;
       if(template.tabular.lastData && template.tabular.data.length == template.tabular.lastData.length){
         redraw = !template.tabular.data.some(function(item, index){
@@ -433,6 +434,19 @@ Template.tabular.onRendered(function () {
 
     // Get the updated list of docs we should be showing
     var cursor = collection.find({_id: {$in: tableInfo.ids}}, findOptions);
+    cursor.observe({
+      changed(newDoc){
+        if(newDoc._id){
+          _.forEach(tableInit.TabularCaches[newDoc._id], function(item, key){
+            //the data for this template may have changed, so re-render
+            //TODO: might be better to check if the values used have changed somehow?
+            if(item.template.dataVar){
+              item.template.dataVar.set(item.template.dataVar.get());
+            }
+          });
+        }
+      }
+    });
     //console.log('tableInfo, fields, sort, find autorun', cursor.count());
 
     // We're subscribing to the docs just in time, so there's

--- a/client/tableInit.js
+++ b/client/tableInit.js
@@ -80,7 +80,7 @@ function templateColumnOptions({ data, render, tmpl, tmplContext }) {
     //Perhaps this can be done in a triggersExit?
     if(rowData._id && tableInit.TabularCaches[rowData._id] && tableInit.TabularCaches[rowData._id][tmplName]){
       cell.innerHTML = tableInit.TabularCaches[rowData._id][tmplName].cell.innerHTML;
-      tableInit.TabularCaches[rowData._id][tmplName].template;
+      return tableInit.TabularCaches[rowData._id][tmplName].template;
     }
     // Allow the table to adjust the template context if desired
     if (typeof tmplContext === 'function') {
@@ -97,6 +97,7 @@ function templateColumnOptions({ data, render, tmpl, tmplContext }) {
         cell: cell
       };
     }
+    return ret;
   };
 
   // If we're displaying a template for this field and we've also provided data, we want to

--- a/client/tableInit.js
+++ b/client/tableInit.js
@@ -79,7 +79,8 @@ function templateColumnOptions({ data, render, tmpl, tmplContext }) {
     //TODO: should really consider clearing this data otherwise it will just grow larger.
     //Perhaps this can be done in a triggersExit?
     if(rowData._id && tableInit.TabularCaches[rowData._id] && tableInit.TabularCaches[rowData._id][tmplName]){
-      cell.innerHTML = tableInit.TabularCaches[rowData._id][tmplName].cell.innerHTML;
+      //cell.innerHTML = tableInit.TabularCaches[rowData._id][tmplName].cell.innerHTML;
+      cell.parentElement.replaceChild(tableInit.TabularCaches[rowData._id][tmplName].cell, cell);
       return tableInit.TabularCaches[rowData._id][tmplName].template;
     }
     // Allow the table to adjust the template context if desired

--- a/client/tableInit.js
+++ b/client/tableInit.js
@@ -79,25 +79,20 @@ function templateColumnOptions({ data, render, tmpl, tmplContext }) {
     //TODO: should really consider clearing this data otherwise it will just grow larger.
     //Perhaps this can be done in a triggersExit?
     if(rowData._id && tableInit.TabularCaches[rowData._id] && tableInit.TabularCaches[rowData._id][tmplName]){
-      cell.innerHTML = tableInit.TabularCaches[rowData._id][tmplName].cell.innerHTML;
-      return tableInit.TabularCaches[rowData._id][tmplName].template;
+      cell.innerHTML = tableInit.TabularCaches[rowData._id][tmplName].innerHTML;
     }
     // Allow the table to adjust the template context if desired
     if (typeof tmplContext === 'function') {
       rowData = tmplContext(rowData);
     }
 
-    const ret = Blaze.renderWithData(tmpl, rowData, cell);
+    Blaze.renderWithData(tmpl, rowData, cell);
     if(rowData._id){
       if(!tableInit.TabularCaches[rowData._id]){
         tableInit.TabularCaches[rowData._id] = {};
       }
-      tableInit.TabularCaches[rowData._id][tmplName] = {
-        template: ret,
-        cell: cell
-      };
+      tableInit.TabularCaches[rowData._id][tmplName] = cell;
     }
-    return ret;
   };
 
   // If we're displaying a template for this field and we've also provided data, we want to

--- a/client/tableInit.js
+++ b/client/tableInit.js
@@ -79,19 +79,23 @@ function templateColumnOptions({ data, render, tmpl, tmplContext }) {
     //TODO: should really consider clearing this data otherwise it will just grow larger.
     //Perhaps this can be done in a triggersExit?
     if(rowData._id && tableInit.TabularCaches[rowData._id] && tableInit.TabularCaches[rowData._id][tmplName]){
-      cell.innerHTML = tableInit.TabularCaches[rowData._id][tmplName].innerHTML;
+      cell.innerHTML = tableInit.TabularCaches[rowData._id][tmplName].cell.innerHTML;
+      tableInit.TabularCaches[rowData._id][tmplName].template;
     }
     // Allow the table to adjust the template context if desired
     if (typeof tmplContext === 'function') {
       rowData = tmplContext(rowData);
     }
 
-    Blaze.renderWithData(tmpl, rowData, cell);
+    const ret = Blaze.renderWithData(tmpl, rowData, cell);
     if(rowData._id){
       if(!tableInit.TabularCaches[rowData._id]){
         tableInit.TabularCaches[rowData._id] = {};
       }
-      tableInit.TabularCaches[rowData._id][tmplName] = cell;
+      tableInit.TabularCaches[rowData._id][tmplName] = {
+        template: ret,
+        cell: cell
+      };
     }
   };
 

--- a/client/tableInit.js
+++ b/client/tableInit.js
@@ -58,8 +58,6 @@ function tableInit(tabularTable, template) {
 };
 
 tableInit.TabularCaches = {};
-
-window.tableInit = tableInit;
 // The `tmpl` column option is special for this package. We parse it into other column options
 // and then remove it.
 function templateColumnOptions({ data, render, tmpl, tmplContext }) {


### PR DESCRIPTION
I noticed that when rendering 50 items per page, where each row had perhaps 4 cells with templates, the load time between pages (even ones already visited) were high. I made this change to make page switches after the initial page visit faster. 

I'm using SubsManager in the table in question, I'm not sure if that is necessary to observe any speedup.