### PR TITLE
Unpolish proposal for Tabular Joins

### DIFF
--- a/package.js
+++ b/package.js
@@ -22,7 +22,8 @@ Package.onUse(function(api) {
     'templating',
     'reactive-var',
     'tracker',
-    'session'
+    'session',
+    'jcbernack:reactive-aggregate'
   ]);
 
   // jquery is a weak reference in case you want to use a different package or


### PR DESCRIPTION
Proposal for Tabular Joins using the mongo aggregator pipeline in both publish with the capability of performing search on the joined collection. 

Usage:
this.table = new Tabular.Table({
    name: 'Test',
    collection: invoiceCollection,
    columns: [
        {data: "invoiceNumber", title: "Invoice Number"},
        {data: "client.profile.name", title:"Cliente"},
        .
        .
        .
    ],
    responsive: true,
    autoWidth: false,
    joins:[
        {from:"users",localField:"createdBy",foreignField:"_id",as:"client",unwind: true (optional)}
    ]
});