### PR TITLE
Fixes #71 by checking the selector for actual changes

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -184,8 +184,9 @@ Template.tabular.onRendered(function () {
     var data = Template.currentData();
 
     //console.log('currentData autorun', data);
-
-    if (!data) return;
+    
+    // if we don't have data OR the selector didn't actually change return out
+    if (!data || template.tabular.selector === data.selector) return;
 
     // We get the current TabularTable instance, and cache it on the
     // template instance for access elsewhere

--- a/client/main.js
+++ b/client/main.js
@@ -186,7 +186,7 @@ Template.tabular.onRendered(function () {
     //console.log('currentData autorun', data);
     
     // if we don't have data OR the selector didn't actually change return out
-    if (!data || template.tabular.selector === data.selector) return;
+    if (!data || (data.selector && template.tabular.selector === data.selector)) return;
 
     // We get the current TabularTable instance, and cache it on the
     // template instance for access elsewhere


### PR DESCRIPTION
Before the selector was always being set which had the effect of 'resetting' the pagination back to zero if the selector was reactively set. As you can see below this fixes the problem:

I haven't tested this with a publish composite but, it should fix things there too.

![pagination fixed](https://cloud.githubusercontent.com/assets/297351/23317554/e8d37184-fa9c-11e6-8cd8-e5eb2f406721.gif)
