### PR TITLE
Update main.js

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -347,6 +347,8 @@ Template.tabular.onRendered(function () {
     const userOptions = template.tabular.options.get();
     const options = _.extend({}, ajaxOptions, userOptions);
 
+    //Allow a reinitializing. For example, if we change an app language
+    Session.get('Tabular.reinit');
     //console.log('userOptions autorun', userOptions);
 
     // unless the user provides her own displayStart,


### PR DESCRIPTION
Allow a reinitializing. For example, if we change an app language.
Below you can see a simple way to make i18n for a tabular table. Just change Session.set("currentLanguage", "lang"), where lang is a language of the user and the tabular table will be reinitialized automatically.
```
<template name="yourtemplatewithtabular">
  {{> tabular table=TabularTables.yourTable id="tabularYourTable" class="ui striped table"}}
</template>
```
```
Template.yourtemplatewithtabular.onCreated(function() {
  Tracker.autorun(function() {
    $.extend(true, $.fn.dataTable.defaults, {
      language: {
        "decimal":        "",
        "emptyTable":     TAPi18n.__("No data available in table"),
        "info":           TAPi18n.__("Showing _START_ to _END_ of _TOTAL_ entries"),
        "infoEmpty":      TAPi18n.__("Showing 0 to 0 of 0 entries"),
        "infoFiltered":   TAPi18n.__("(filtered from _MAX_ total entries)"),
        "infoPostFix":    "",
        "thousands":      ",",
        "lengthMenu":     TAPi18n.__("Show _MENU_ entries"),
        "loadingRecords": TAPi18n.__("Loading"),
        "processing":     TAPi18n.__("Processing"),
        "search":         TAPi18n.__("Search"),
        "zeroRecords":    TAPi18n.__("No matching records found"),
        "paginate": {
          "first":      TAPi18n.__("First"),
          "last":       TAPi18n.__("Last"),
          "next":       TAPi18n.__("Next"),
          "previous":   TAPi18n.__("Previous")
        },
        "aria": {
          "sortAscending":  TAPi18n.__("activate to sort column ascending"),
          "sortDescending": TAPi18n.__("activate to sort column descending")
        }
      }
    });
    Session.set('Tabular.reinit', Session.get("currentLanguage"));
  });
  dataTablesSemanticUI(window, $);
});
```